### PR TITLE
fix sourceweb compilation under llvm 3.6.2

### DIFF
--- a/clang-indexer/TUIndexer.cc
+++ b/clang-indexer/TUIndexer.cc
@@ -74,17 +74,17 @@ private:
         return *m_context;
     }
 
-    virtual clang::ASTConsumer *CreateASTConsumer(
+    virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
             clang::CompilerInstance &ci,
             llvm::StringRef inFile) {
-        return new IndexerASTConsumer(getContext(ci));
+        return std::unique_ptr<clang::ASTConsumer>(new IndexerASTConsumer(getContext(ci)));
     }
 
     virtual bool BeginSourceFileAction(clang::CompilerInstance &ci,
                                        llvm::StringRef filename) {
         ci.getDiagnostics().setClient(new clang::IgnoringDiagConsumer);
         ci.getPreprocessor().addPPCallbacks(
-                    new IndexerPPCallbacks(getContext(ci)));
+                    std::unique_ptr<IndexerPPCallbacks>(new IndexerPPCallbacks(getContext(ci))));
         return true;
     }
 


### PR DESCRIPTION
sourceweb does not compile when `make` under llvm-clang with version 3.6.2, which seems to be caused by API change. This is a possible fix.