### PR TITLE
Update for clang 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SourceWeb currently runs on Linux and OS X.
 
 SourceWeb is written in C++11.  The indexer links against Clang's C++ API.
 Clang's C++ APIs are not compatible between releases, so this version of
-SourceWeb requires exactly Clang 3.7.  The GUI uses Qt 4.6 or later.  Follow
+SourceWeb requires exactly Clang 3.8.  The GUI uses Qt 4.6 or later.  Follow
 the build instructions to satisfy these dependencies.
 
 
@@ -24,7 +24,7 @@ Install prerequisite packages:
 Debian-based:
 
     sudo apt-get install make g++ libqt4-dev zlib1g-dev libncurses5-dev \
-                         libclang-3.7-dev llvm-3.7-dev
+                         libclang-3.8-dev llvm-3.8-dev
 
 Fedora/CentOS:
 

--- a/check-clang.pri
+++ b/check-clang.pri
@@ -3,7 +3,7 @@
 # Clang installation.
 #
 
-REQUIRED_CLANG_VERSION = 3.7
+REQUIRED_CLANG_VERSION = 3.8
 
 equals(CLANG_DIR, "") {
     warning("The CLANG_DIR qmake variable is unset.")

--- a/clang-indexer/ASTIndexer.cc
+++ b/clang-indexer/ASTIndexer.cc
@@ -37,22 +37,6 @@ ASTIndexer::ASTIndexer(IndexerContext &indexerContext) :
 {
 }
 
-bool ASTIndexer::shouldUseDataRecursionFor(clang::Stmt *s) const
-{
-    if (s == NULL || !base::shouldUseDataRecursionFor(s))
-        return false;
-    if (clang::UnaryOperator *e = llvm::dyn_cast<clang::UnaryOperator>(s)) {
-        return e->getOpcode() >= clang::UO_Plus &&
-                e->getOpcode() <= clang::UO_Imag;
-    }
-    if (clang::BinaryOperator *e = llvm::dyn_cast<clang::BinaryOperator>(s)) {
-        return e->getOpcode() >= clang::BO_Mul &&
-                e->getOpcode() <= clang::BO_LOr;
-    }
-    return false;
-}
-
-
 ///////////////////////////////////////////////////////////////////////////////
 // Dispatcher routines
 

--- a/clang-indexer/ASTIndexer.h
+++ b/clang-indexer/ASTIndexer.h
@@ -45,7 +45,6 @@ private:
 
     // Misc routines
     bool shouldVisitTemplateInstantiations() const { return true; }
-    bool shouldUseDataRecursionFor(clang::Stmt *s) const;
 
     // Dispatcher routines
     bool TraverseStmt(clang::Stmt *stmt);

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -u
 
-CLANG_VER=3.7
+CLANG_VER=3.8
 SRCDIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {


### PR DESCRIPTION
This commit broke the build: https://github.com/llvm-mirror/clang/commit/89d5b46c217bb7fd5d23e92def8f9a6edd57090a

I don't really know whether this is the correct thing to do, but the result seems to work.