### PR TITLE
Register macro expansion source location for declarations from macros…

### DIFF
--- a/clang-indexer/ASTIndexer.cc
+++ b/clang-indexer/ASTIndexer.cc
@@ -437,6 +437,7 @@ bool ASTIndexer::VisitDecl(clang::Decl *d)
 {
     if (clang::NamedDecl *nd = llvm::dyn_cast<clang::NamedDecl>(d)) {
         clang::SourceLocation loc = nd->getLocation();
+        loc = m_indexerContext.sourceManager().getFileLoc(loc);
         if (clang::FunctionDecl *fd = llvm::dyn_cast<clang::FunctionDecl>(d)) {
             if (fd->getTemplateInstantiationPattern() != NULL) {
                 // When Clang instantiates a function template, it seems to


### PR DESCRIPTION
… instead of <scratch space>