### PR TITLE
Sourceweb ported to LLVM-4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SourceWeb currently runs on Linux and OS X.
 
 SourceWeb is written in C++11.  The indexer links against Clang's C++ API.
 Clang's C++ APIs are not compatible between releases, so this version of
-SourceWeb requires exactly Clang 3.8.  The GUI uses Qt 4.6 or later.  Follow
+SourceWeb requires exactly Clang 4.0.  The GUI uses Qt 4.6 or later.  Follow
 the build instructions to satisfy these dependencies.
 
 

--- a/check-clang.pri
+++ b/check-clang.pri
@@ -3,7 +3,7 @@
 # Clang installation.
 #
 
-REQUIRED_CLANG_VERSION = 3.8
+REQUIRED_CLANG_VERSION = 4.0
 
 equals(CLANG_DIR, "") {
     warning("The CLANG_DIR qmake variable is unset.")
@@ -31,7 +31,7 @@ CLANG_LIBS = \
     clangTooling clangParse clangSema clangAnalysis \
     clangEdit clangAST clangLex clangBasic \
     LLVMMC LLVMMCParser LLVMObject LLVMAsmParser LLVMCore LLVMProfileData LLVMSupport \
-    LLVMOption LLVMBitWriter LLVMBitReader
+    LLVMOption LLVMBitWriter LLVMBitReader LLVMDemangle
 for(CLANG_LIB, CLANG_LIBS) {
     checkClangRequire($${CLANG_DIR}/lib/lib$${CLANG_LIB}.a)
 }

--- a/clang-indexer/IndexerContext.cc
+++ b/clang-indexer/IndexerContext.cc
@@ -158,7 +158,8 @@ IndexerFileContext &IndexerContext::fileContext(clang::FileID fileID)
         const clang::FileEntry *pFE =
                 m_sourceManager.getFileEntryForID(fileID);
         if (pFE != NULL) {
-            char *filename = portableRealPath(pFE->getName());
+            llvm::StringRef fname = pFE->getName();
+            char* filename = portableRealPath(fname.data());
             if (filename != NULL) {
                 pathSymbolName += filename;
                 free(filename);

--- a/clang-indexer/IndexerPPCallbacks.cc
+++ b/clang-indexer/IndexerPPCallbacks.cc
@@ -43,7 +43,8 @@ void IndexerPPCallbacks::InclusionDirective(
     auto it = m_includePathMap.find(file);
     if (it == m_includePathMap.end()) {
         std::string symbol = "@";
-        char *path = portableRealPath(file->getName());
+        llvm::StringRef fname = file->getName();
+        char *path = portableRealPath(fname.data());
         if (path != NULL) {
             symbol += path;
             free(path);

--- a/clang-indexer/NameGenerator.cc
+++ b/clang-indexer/NameGenerator.cc
@@ -109,7 +109,8 @@ void NameGenerator::VisitDeclContext(clang::DeclContext *context)
             const clang::FileEntry *fileEntry =
                     sourceManager.getFileEntryForID(fileID);
             if (fileEntry != NULL) {
-                m_out << const_basename(fileEntry->getName());
+                llvm::StringRef fname = fileEntry->getName();
+                m_out << const_basename(fname.data());
                 if (m_needOffsetPrefix)
                     m_out << '@' << sourceManager.getFileOffset(sloc);
                 m_out << '/';

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -u
 
-CLANG_VER=3.8
+CLANG_VER=4.0
 SRCDIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {


### PR DESCRIPTION
This patch ports Sourceweb from LLVM-3.8 to LLVM-4.0.

Tested on: gcc (GCC) 7.1.1 20170630 | LLVM version 4.0.1 | Linux x86_64